### PR TITLE
Add "warning" instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [@repeat](#repeat)
     - [@if – @elseif – @else](#if--elseif--else)
     - [@error](#error)
+    - [@warning](#warning)
   - [Filters](#filters)
   - [Expressions](#expressions)
     - [Types](#types)
@@ -347,6 +348,29 @@ Emits an error.
   // platform 3 code
 <b>@else</b>
   <b>@error</b> "Platform is " + PLATFORM + " is unsupported"
+<b>@endif</b>
+</pre>
+
+### @warning
+
+<pre>
+<b>@warning</b> <i>&lt;message:expression&gt;</i>
+</pre>
+
+Emits a warning.
+
+#### Example
+
+<pre>
+<b>@if</b> PLATFORM == "platform1"
+  // platform 1 code
+<b>@elseif</b> PLATFORM == "platform2"
+  // platform 2 code
+<b>@elseif</b> PLATFORM == "platform3"
+  // platform 3 code
+<b>@else</b>
+  <b>@warning</b> "Building for default platform"
+  // default platform code
 <b>@endif</b>
 </pre>
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jasmine": "^2.4.1",
     "jasmine-diff-matchers": "^2.0.0",
     "jasmine-expect": "^2.0.2",
-    "log": "^1.4.0"
+    "log": "^1.4.0",
+    "fixture-stdout": "^0.2.1"
   }
 }

--- a/spec/AstParser/incorrect-syntax.spec.js
+++ b/spec/AstParser/incorrect-syntax.spec.js
@@ -86,6 +86,15 @@ describe('Tokenizer', () => {
     }
   });
 
+  it('should detect incorrect @warning syntax', () => {
+    try {
+      parser.parse(`@warning`);
+      fail();
+    } catch (e) {
+      expect(e.message).toBe('Syntax error in @warning (main:1)');
+    }
+  });
+
   it('should detect incorrect @else syntax', () => {
     try {
       parser.parse(`@if 1\n@else 0\n@endif`);

--- a/spec/Machine/basic.spec.js
+++ b/spec/Machine/basic.spec.js
@@ -6,6 +6,8 @@
 
 require('jasmine-expect');
 
+const Fixture = require('fixture-stdout');
+const stdoutFixture = new Fixture({ stream: process.stderr });
 const init = require('./init')('main');
 const Machine = require('../../src/Machine');
 
@@ -78,6 +80,32 @@ describe('Machine', () => {
     } catch (e) {
       expect(e instanceof Machine.Errors.UserDefinedError).toBe(true);
       expect(e.message).toBe('abc');
+    }
+  });
+
+  it('should handle @warning directives', (done) => {
+    // Our warning message
+    const text = 'abc';
+    // What we expect to be logged to STDERR
+    const yellowTextLine = `\x1b[33m${text}\u001b[39m\n`;
+    try {
+      // Capture STDERR messages
+      stdoutFixture.capture(message => {
+        try {
+          expect(message).toBe(yellowTextLine);
+          // Release STDERR
+          stdoutFixture.release();
+          done();
+        } catch (e) {
+          fail(e);
+        }
+        // Returning false prevents message actually being logged to STDERR
+        return false;
+      });
+
+      machine.execute(`@warning "${text}"`);
+    } catch (e) {
+      fail(e);
     }
   });
 

--- a/src/AstParser.js
+++ b/src/AstParser.js
@@ -56,14 +56,15 @@ const TOKENS = {
   ENDMACRO: 'endmacro',
   ENDREPEAT: 'endrepeat',
   SOURCE_FRAGMENT: 'source_fragment',
-  INLINE_EXPRESSION: 'inline_expression'
+  INLINE_EXPRESSION: 'inline_expression',
+  WARNING: 'warning',
 };
 
 // lines gobbling regex
 const LINES = /(.*(?:\r\n|\n)?)/g;
 
 // regex to detect if fragment is a directive
-const DIRECTIVE = /^\s*@(include|set|if|else|elseif|endif|error|macro|endmacro|end|while|endwhile|repeat|endrepeat)\b(.*?)\s*$/;
+const DIRECTIVE = /^\s*@(include|set|if|else|elseif|endif|error|macro|endmacro|end|while|endwhile|repeat|endrepeat|warning)\b(.*?)\s*$/;
 
 // @-style comments regex
 const COMMENT = /^\s*@\s/;
@@ -186,6 +187,12 @@ class AstParser {
           case 'error':
             this._checkArgumentIsNonempty(type, arg, token._line);
             token.type = TOKENS.ERROR;
+            token.args.push(arg);
+            break;
+
+          case 'warning':
+            this._checkArgumentIsNonempty(type, arg, token._line);
+            token.type = TOKENS.WARNING;
             token.args.push(arg);
             break;
 
@@ -382,6 +389,15 @@ class AstParser {
         case TOKENS.ERROR:
 
           node.type = INSTRUCTIONS.ERROR;
+          node.value = token.args[0];
+          this._append(parent, node, state);
+
+          break;
+
+        // @warning <message:expression>
+        case TOKENS.WARNING:
+
+          node.type = INSTRUCTIONS.WARNING;
           node.value = token.args[0];
           this._append(parent, node, state);
 

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -37,6 +37,7 @@ const INSTRUCTIONS = {
   SET: 'set',
   LOOP: 'loop',
   ERROR: 'error',
+  WARNING: 'warning',
   MACRO: 'macro',
   OUTPUT: 'output',
   INCLUDE: 'include',
@@ -198,6 +199,10 @@ class Machine {
 
           case INSTRUCTIONS.ERROR:
             this._executeError(instruction, context, buffer);
+            break;
+
+          case INSTRUCTIONS.WARNING:
+            this._executeWarning(instruction, context, buffer);
             break;
 
           case INSTRUCTIONS.MACRO:
@@ -381,7 +386,7 @@ class Machine {
   }
 
   /**
-   * Execute "error: instruction
+   * Execute "error" instruction
    * @param {{type, value}} instruction
    * @param {{}} context
    * @param {string[]} buffer
@@ -392,6 +397,19 @@ class Machine {
       this.expression.evaluate(instruction.value,
         this._mergeContexts(this._globalContext, context))
     );
+  }
+
+  /**
+   * Execute "warning" instruction
+   * @param {{type, value}} instruction
+   * @param {{}} context
+   * @param {string[]} buffer
+   * @private
+   */
+  _executeWarning(instruction, context, buffer) {
+    const message = this.expression.evaluate(instruction.value,
+      this._mergeContexts(this._globalContext, context));
+    console.error("\x1b[33m" + message + '\u001b[39m');
   }
 
   /**


### PR DESCRIPTION
Like `@error`, `@warning` logs a message/expression to stderr.  `@warning` does not halt execution or change the exit status.  `@warning` logs in yellow instead of red.  Tests and documentation updates are included.

I'm migrating my projects from Wrench to Builder.  Most directives have direct analogs, but Wrench's `#warning` is missing in Builder.  `#warning` is used to log some text to bring to the user's attention, but allow the build to complete (unlike Builder's `@error` which halts the build and exits with an error code).