### PR TITLE
--use-dependencies does not always turn off caching

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2016-2019 Electric Imp
+Copyright 2016-2020 Electric Imp
 
 SPDX-License-Identifier: MIT
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ where `<input_file>` is the path to source file which should be preprocessed and
 | --lib | --libs | No | Yes | Include the specified [JavaScript file(s) as a library](#including-javascript-libraries). May be specified several times to include multiple libraries. The provided value may specify a concrete file or a directory (all files from the directory will be included). The value may contain [wildcards](https://www.npmjs.com/package/glob) (all matched files will be included) |
 | --use-remote-relative-includes | | No | No | Interpret every [local include](#include) as relative to the location of the source file where it is mentioned. See ['Local Includes From Remote Files'](#local-includes-from-remote-files) |
 | --suppress-duplicate-includes-warning | --suppress-duplicate | No | No | Do not show a warning if a source file with the same content was included multiple times from different locations and this results in code duplication |
-| --cache | -c | No | No | Turn on caching for all files included from remote resources. This option is ignored if the `--save-dependencies` option is specified or `--use-dependencies` options is specified and reference to appropriate file is saved. See [‘Caching Remote Includes’](#caching-remote-includes) |
+| --cache | -c | No | No | Turn on caching for all files included from remote resources. See [‘Caching Remote Includes’](#caching-remote-includes). This option is ignored if the `--save-dependencies` option is specified (the cache is turned off for all files in this case). If the `--use-dependencies` option is specified the cache is turned off for the files referenced in the dependency file and is turned on for all other remote files |
 | --clear-cache | | No | No | Clear the cache before Builder starts running. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --cache-exclude-list | | No | Yes | Set the path to the file that lists resources which should not be cached. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --save-dependencies | | No | No | Save references to the required GitHub files in the specified file. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
@@ -775,7 +775,7 @@ These options are processed the following way:
     3. Builder performs the preprocessing operation.
     4. References to all source files retrieved from GitHub are saved in the JSON file passed to the `--save-dependencies` option (or `dependencies.json`).
 
-**Note** If `--save-dependencies` is specified or `--use-dependencies` is specified and reference to file exists, the `--cache` option is ignored.
+**Note** If `--save-dependencies` is specified, the `--cache` option is ignored. If `--use-dependencies` is specified, the `--cache` option does not affect the files referenced in the dependency file.
 
 A typical `dependencies.json` file looks like this:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ where `<input_file>` is the path to source file which should be preprocessed and
 | --lib | --libs | No | Yes | Include the specified [JavaScript file(s) as a library](#including-javascript-libraries). May be specified several times to include multiple libraries. The provided value may specify a concrete file or a directory (all files from the directory will be included). The value may contain [wildcards](https://www.npmjs.com/package/glob) (all matched files will be included) |
 | --use-remote-relative-includes | | No | No | Interpret every [local include](#include) as relative to the location of the source file where it is mentioned. See ['Local Includes From Remote Files'](#local-includes-from-remote-files) |
 | --suppress-duplicate-includes-warning | --suppress-duplicate | No | No | Do not show a warning if a source file with the same content was included multiple times from different locations and this results in code duplication |
-| --cache | -c | No | No | Turn on caching for all files included from remote resources. This option is ignored if the `--save-dependencies` or `--use-dependencies` options are specified. See [‘Caching Remote Includes’](#caching-remote-includes) |
+| --cache | -c | No | No | Turn on caching for all files included from remote resources. This option is ignored if the `--save-dependencies` option is specified or `--use-dependencies` options is specified and reference to appropriate file is saved. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --clear-cache | | No | No | Clear the cache before Builder starts running. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --cache-exclude-list | | No | Yes | Set the path to the file that lists resources which should not be cached. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --save-dependencies | | No | No | Save references to the required GitHub files in the specified file. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
@@ -775,7 +775,7 @@ These options are processed the following way:
     3. Builder performs the preprocessing operation.
     4. References to all source files retrieved from GitHub are saved in the JSON file passed to the `--save-dependencies` option (or `dependencies.json`).
 
-**Note** If either `--save-dependencies` or `--use-dependencies` is specified, the `--cache` option is ignored.
+**Note** If `--save-dependencies` is specified or `--use-dependencies` is specified and reference to file exists, the `--cache` option is ignored.
 
 A typical `dependencies.json` file looks like this:
 

--- a/spec/Machine/cache.spec.js
+++ b/spec/Machine/cache.spec.js
@@ -164,8 +164,6 @@ describe('FileCache', () => {
     const dependenciesFile = path.join(process.cwd(), 'test-dependencies.json');
     const link1 = 'github:electricimp/Builder/spec/fixtures/sample-1/input.nut.out';
     const link2 = 'github:electricimp/Builder/spec/fixtures/sample-1/input.nut.json';
-    const link3 = 'github:electricimp/Builder/spec/fixtures/sample-1/inc-b.nut';
-    machine.clearCache();
     machine.useCache = true;
 
     // --save-dependencies is on, --use-dependencies is off, reference to file
@@ -221,23 +219,15 @@ describe('FileCache', () => {
     machine.clearCache();
     machine.dependenciesSaveFile = dependenciesFile;
     machine.dependenciesUseFile = dependenciesFile;
-    machine.execute(
-      `@include "${link2}"
-@include "${link3}"`);
+    machine.execute(`@include "${link2}"`);
     ghRes = machine.fileCache._getCachedPath(link2);
-    expect(fs.existsSync(ghRes)).toEqual(false);
-    ghRes = machine.fileCache._getCachedPath(link3);
     expect(fs.existsSync(ghRes)).toEqual(false);
 
     // --save-dependencies is on, --use-dependencies is on, reference to file
     // is included
     machine.clearCache();
-    machine.execute(
-      `@include "${link2}"
-@include "${link3}"`);
+    machine.execute(`@include "${link2}"`);
     ghRes = machine.fileCache._getCachedPath(link2);
-    expect(fs.existsSync(ghRes)).toEqual(false);
-    ghRes = machine.fileCache._getCachedPath(link3);
     expect(fs.existsSync(ghRes)).toEqual(false);
 
     machine.clearCache();

--- a/spec/Machine/cache.spec.js
+++ b/spec/Machine/cache.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Electric Imp
+// Copyright (c) 2016-2020 Electric Imp
 // This file is licensed under the MIT License
 // http://opensource.org/licenses/MIT
 
@@ -7,6 +7,7 @@
 require('jasmine-expect');
 
 const init = require('./init')('main');
+const path = require('path');
 const Machine = require('../../src/Machine');
 const fs = require('fs');
 
@@ -157,6 +158,92 @@ describe('FileCache', () => {
       expect(linksSet.has(path)).toEqual(false);
       linksSet.add(path);
     });
+  });
+
+  it('should cache files or read from cache if use-dependencies options is on, save-dependencies if off, and dependencies do not include the file', () => {
+    const dependenciesFile = path.join(process.cwd(), 'test-dependencies.json');
+    const link1 = 'github:electricimp/Builder/spec/fixtures/sample-1/input.nut.out';
+    const link2 = 'github:electricimp/Builder/spec/fixtures/sample-1/input.nut.json';
+    const link3 = 'github:electricimp/Builder/spec/fixtures/sample-1/inc-b.nut';
+    machine.clearCache();
+    machine.useCache = true;
+
+    // --save-dependencies is on, --use-dependencies is off, reference to file
+    // is not included
+    machine.clearCache();
+    machine.dependenciesSaveFile = dependenciesFile;
+    machine.dependenciesUseFile = undefined;
+    machine.execute(`@include "${link2}"`);
+    let ghRes = machine.fileCache._getCachedPath(link2);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+
+    // --save-dependencies is on, --use-dependencies is off, reference to file
+    // is included
+    machine.clearCache();
+    machine.execute(`@include "${link2}"`);
+    ghRes = machine.fileCache._getCachedPath(link2);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+
+    // --save-dependencies is off, --use-dependencies is on, reference to file
+    // is not included
+    machine.clearCache();
+    machine.dependenciesSaveFile = undefined;
+    machine.dependenciesUseFile = dependenciesFile;
+    machine.execute(`@include "${link1}"`);
+    ghRes = machine.fileCache._getCachedPath(link1);
+    expect(fs.existsSync(ghRes)).toEqual(true);
+
+    // prepare to next check
+    fs.unlinkSync(dependenciesFile);
+    machine.clearCache();
+    machine.dependenciesSaveFile = dependenciesFile;
+    machine.dependenciesUseFile = undefined;
+    machine.execute(`@include "${link1}"`);
+
+    // --save-dependencies is off, --use-dependencies is on, reference to file
+    // is included
+    machine.clearCache();
+    machine.dependenciesSaveFile = undefined;
+    machine.dependenciesUseFile = dependenciesFile;
+    machine.execute(`@include "${link1}"`);
+    ghRes = machine.fileCache._getCachedPath(link1);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+
+    // prepare to next check
+    fs.unlinkSync(dependenciesFile);
+    machine.clearCache();
+    machine.dependenciesSaveFile = dependenciesFile;
+    machine.dependenciesUseFile = undefined;
+    machine.execute(`@include "${link1}"`);
+
+    // --save-dependencies is on, --use-dependencies is on, reference to file
+    // is not included
+    machine.clearCache();
+    machine.dependenciesSaveFile = dependenciesFile;
+    machine.dependenciesUseFile = dependenciesFile;
+    machine.execute(
+      `@include "${link2}"
+@include "${link3}"`);
+    ghRes = machine.fileCache._getCachedPath(link2);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+    ghRes = machine.fileCache._getCachedPath(link3);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+
+    // --save-dependencies is on, --use-dependencies is on, reference to file
+    // is included
+    machine.clearCache();
+    machine.execute(
+      `@include "${link2}"
+@include "${link3}"`);
+    ghRes = machine.fileCache._getCachedPath(link2);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+    ghRes = machine.fileCache._getCachedPath(link3);
+    expect(fs.existsSync(ghRes)).toEqual(false);
+
+    machine.clearCache();
+    machine.dependenciesSaveFile = undefined;
+    machine.dependenciesUseFile = undefined;
+    fs.unlinkSync(dependenciesFile);
   });
 
 });

--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2020 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -140,7 +140,12 @@ class FileCache {
    */
   read(reader, includePath, dependencies) {
     let needCache = false;
-    if (!dependencies && this._toBeCached(includePath) && this._isCachedReader(reader)) {
+    // Cache file or read from cache only if --cache option is on and no
+    // --save-dependencies option is used
+    // If --use-dependencies option is used (together with --cache, of course),
+    // then cache file or read from cache if no reference to it found in the specified file
+    const depCondition = (!dependencies || dependencies.get(includePath) === undefined) && !this.machine.dependenciesSaveFile;
+    if (depCondition && this._toBeCached(includePath) && this._isCachedReader(reader)) {
       let result;
       if ((result = this._findFile(includePath)) && !this._isCacheFileOutdate(result)) {
         // change reader to local reader


### PR DESCRIPTION
The problem was that using of `--use-dependencies` option turned off caching or reading from cache for **all** the files, even the files what is not related to dependencies file.

[Changing a conditional expression](https://github.com/electricimp/Builder/blob/e094fb23c771c23241f9f7cfa7e2c1d38f6905eb/src/FileCache.js#L143-L148) solved this issue.

`--save-dependencies` option turns off caching or reading from cache for all files.
If `--use-dependencies` option is on, `--save-dependencies` option is off, and processed file is not included into dependencies, then this file can be cached or read from cache.
[Appropriate test](https://github.com/electricimp/Builder/blob/550d5c1773aa33ab0c64dcbdacc67895d28bc432/spec/Machine/cache.spec.js#L173-L247) is added.

For examples, if we have two links:
```
const link1 = 'github:nobitlost/Builder/spec/fixtures/sample-1/input.nut.out';
const link2 = 'github:nobitlost/Builder/spec/fixtures/sample-1/input.nut.json';
```
and trying to execute with `--use-dependencies` and `--cache` options:
```
@include "${link1}"
@include "${link2}"
```
and these paths are not included into dependencies file, then both files will be cached or read from cache.
If we have a reference to `${link1} `file in dependencies file, and trying to execute with `--use-dependencies` and `--cache` options:
```
@include "${link1}"
@include "${link2}"
```
then `${link2} ` only will will be cached or read from cache.